### PR TITLE
Escape ini values

### DIFF
--- a/background/script.js
+++ b/background/script.js
@@ -109,9 +109,9 @@ function extractPrincipalPlusRoleAndAssumeRole(samlattribute, SAMLAssertion) {
 		else {
 			// On succesful API response create file with the STS keys
 			var docContent = "[default] \n" +
-			"aws_access_key_id = " + data.Credentials.AccessKeyId + " \n" +
-			"aws_secret_access_key = " + data.Credentials.SecretAccessKey + " \n" +
-			"aws_session_token = " + data.Credentials.SessionToken;
+			"aws_access_key_id = \"" + data.Credentials.AccessKeyId + "\" \n" +
+			"aws_secret_access_key = \"" + data.Credentials.SecretAccessKey + "\" \n" +
+			"aws_session_token = \"" + data.Credentials.SessionToken + "\"";
 
 			// If there are no Role ARNs configured in the options panel, continue to create credentials file
 			// Otherwise, extend docContent with a profile for each specified ARN in the options panel
@@ -145,9 +145,9 @@ function assumeAdditionalRole(profileList, index, AccessKeyId, SecretAccessKey, 
 		else {
 			docContent += " \n\n" +
 			"[" + profileList[index] + "] \n" +
-			"aws_access_key_id = " + data.Credentials.AccessKeyId + " \n" +
-			"aws_secret_access_key = " + data.Credentials.SecretAccessKey + " \n" +
-			"aws_session_token = " + data.Credentials.SessionToken;
+			"aws_access_key_id = \"" + data.Credentials.AccessKeyId + "\" \n" +
+			"aws_secret_access_key = \"" + data.Credentials.SecretAccessKey + "\" \n" +
+			"aws_session_token = \"" + data.Credentials.SessionToken + "\"";
 		}
 		// If there are more profiles/roles in the RoleArns dict, do another call of assumeAdditionalRole to extend the docContent with another profile
 		// Otherwise, this is the last profile/role in the RoleArns dict. Proceed to creating the credentials file


### PR DESCRIPTION
Since the session token are base64 encoded, the tokens can contain an equals sign. Not all ini file (e.g. [parse_ini_file](http://php.net/manual/en/function.parse-ini-file.php)) parsers accept the token when it is not escaped.